### PR TITLE
Add EasyNMT to translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@
 ## 🗺 Translation
 *Translating between different languages.*
 * [dl-translate](https://github.com/xhlulu/dl-translate) - A deep learning-based translation library based on HF Transformers.
-* [EasyNMT](https://github.com/UKPLab/EasyNMT) - Easy-to-use, state-of-the-art translation library and Docker images based on HF Transformers.
+* [EasyNMT](https://github.com/UKPLab/EasyNMT) (from UKPLab) - Easy-to-use, state-of-the-art translation library and Docker images based on HF Transformers.
 
 ## 📖 Knowledge and Entity
 *Learning knowledge, mining entities, connecting the world.*


### PR DESCRIPTION
Add EasyNMT (https://github.com/UKPLab/EasyNMT) to translation section. Is based on transformers with automatic language detection, long document translation, REST APIs etc.