### PR TITLE
Add "AI Security Tools" section and Veritensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ This is a list of some wonderful open-source projects & applications integrated 
 * [TextFlint](https://github.com/textflint/textflint) (from Fudan) - A unified multilingual robustness evaluation toolkit for NLP.
 * [OpenAttack](https://github.com/thunlp/OpenAttack) (from THU) - An open-source textual adversarial attack toolkit.
 
+## 🔒 AI Security Tools
+* [Veritensor](https://github.com/ArseniiBrazhnyk/Veritensor) - Zero-trust security scanner for AI models. Verifies integrity against the Hub API, detects malware in Pickle/PyTorch files, and checks license compliance.
+
 ## 🔁 Style Transfer
 *Transfer the style of text! Now you know why it's called transformer?*
 * [Styleformer](https://github.com/PrithivirajDamodaran/Styleformer) - A neural language style transfer framework to transfer text smoothly between styles.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This is a list of some wonderful open-source projects & applications integrated 
 * [OpenAttack](https://github.com/thunlp/OpenAttack) (from THU) - An open-source textual adversarial attack toolkit.
 
 ## 🔒 AI Security Tools
-* [Veritensor](https://github.com/ArseniiBrazhnyk/Veritensor) - Zero-trust security scanner for AI models. Verifies integrity against the Hub API, detects malware in Pickle/PyTorch files, and checks license compliance.
+* [Veritensor](https://github.com/arsbr/Veritensor) - Security scanner for Hugging Face artifacts. Verifies model hash integrity against the Hub API and detects malware in Pickle/PyTorch files and Parquet datasets.
 
 ## 🔁 Style Transfer
 *Transfer the style of text! Now you know why it's called transformer?*


### PR DESCRIPTION
Hi team!

As the Hugging Face ecosystem grows, Supply Chain Security is becoming a critical part of the MLOps workflow. I would like to propose adding a new section: "AI Security Tools" (or similar), and submitting Veritensor as an entry.

Veritensor is an open-source CLI specifically designed to secure the consumption of Hugging Face models and datasets.

**Why it fits**:
- **Identity Verification:** It calculates local file hashes and queries the HF API to ensure the downloaded file matches the official upstream version bit-for-bit (detecting MITM or corruption).
- **LFS Validation:** Automatically detects broken Git LFS pointers (a common issue when downloading models).
- **Malware & Poisoning Detection:** Performs static analysis on Pickle/PyTorch models and streams Parquet datasets downloaded from the Hub to detect RCE and malicious URLs.

**Repo:** [https://github.com/arsbr/Veritensor](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2FArseniiBrazhnyk%2FVeritensor)
**License:** Apache 2.0

Proposed entry for the README.md:
- [Veritensor](https://github.com/arsbr/Veritensor) - Security scanner for Hugging Face artifacts. Verifies model hash integrity against the Hub API and detects malware in Pickle/PyTorch files and Parquet datasets.

If you prefer not to create a new section, please feel free to merge this under "Utilities" or "Tools". Thanks for maintaining this awesome list!